### PR TITLE
fix(as#141): as styles の --kesson-* 全廃 (techo#128 Phase 1b)

### DIFF
--- a/dev-components.html
+++ b/dev-components.html
@@ -51,7 +51,7 @@
     .ds-kicker,
     .ds-chip,
     code {
-      font-family: var(--kesson-font-mono-ui);
+      font-family: var(--ds-font-mono-ui);
     }
 
     .ds-kicker,

--- a/src/styles/about-modal.css
+++ b/src/styles/about-modal.css
@@ -32,12 +32,12 @@
 
 .about-trigger:focus-visible,
 .about-close:focus-visible {
-  outline: 2px solid var(--kesson-focus-ring);
+  outline: 2px solid var(--ds-focus-ring);
   outline-offset: 2px;
 }
 
 .about-trigger__letter {
-  font-family: var(--kesson-font-serif-ui);
+  font-family: var(--ds-font-serif-ui);
   font-size: 1.2rem;
   font-style: italic;
   line-height: 1;
@@ -115,7 +115,7 @@
 }
 
 .about-body {
-  font-family: var(--kesson-font-serif-display);
+  font-family: var(--ds-font-serif-display);
   color: rgba(var(--color-highlight), 0.86);
   font-size: 0.93rem;
   line-height: 1.95;
@@ -125,7 +125,7 @@
 .about-body h1,
 .about-body h2 {
   color: rgba(var(--color-heading), 0.94);
-  font-family: var(--kesson-font-serif-display);
+  font-family: var(--ds-font-serif-display);
   font-weight: 400;
   letter-spacing: 0.08em;
 }

--- a/src/styles/awareness.css
+++ b/src/styles/awareness.css
@@ -5,23 +5,23 @@ body.awareness-page {
   --awareness-hero-tagline-sub-rgb: 80, 105, 146;
   --awareness-ui-text-rgb: 74, 102, 145;
   --awareness-ui-text-strong-rgb: 43, 66, 108;
-  --kesson-topbar-divider-color: rgba(var(--awareness-ui-text-rgb), 0.34);
-  --kesson-topbar-title-color: rgba(var(--awareness-ui-text-strong-rgb), 0.96);
-  --kesson-topbar-title-hover-color: rgba(var(--awareness-ui-text-strong-rgb), 1);
-  --kesson-topbar-subtitle-color: rgba(var(--awareness-ui-text-rgb), 0.82);
-  --kesson-topbar-meta-color: rgba(var(--awareness-ui-text-rgb), 0.78);
-  --kesson-topbar-meta-author-color: rgba(var(--awareness-ui-text-rgb), 0.8);
-  --kesson-topbar-link-color: rgba(var(--awareness-ui-text-rgb), 0.86);
-  --kesson-topbar-link-hover-color: rgba(var(--awareness-ui-text-strong-rgb), 0.98);
-  --kesson-topbar-link-hover-bg: rgba(var(--awareness-ui-text-rgb), 0.12);
-  --kesson-topbar-note-divider-color: rgba(var(--awareness-ui-text-rgb), 0.26);
-  --kesson-topbar-note-color: rgba(var(--awareness-ui-text-rgb), 0.82);
-  --kesson-topbar-lang-color: rgba(var(--awareness-ui-text-strong-rgb), 0.96);
-  --kesson-topbar-lang-border: rgba(var(--awareness-ui-text-rgb), 0.32);
-  --kesson-topbar-lang-bg: rgba(var(--awareness-ui-text-rgb), 0.1);
-  --kesson-topbar-nav-border: rgba(var(--awareness-ui-text-rgb), 0.22);
-  --kesson-topbar-toggler-border: rgba(var(--awareness-ui-text-rgb), 0.55);
-  --kesson-topbar-toggler-focus: rgba(var(--awareness-ui-text-rgb), 0.28);
+  --as-topbar-divider-color: rgba(var(--awareness-ui-text-rgb), 0.34);
+  --as-topbar-title-color: rgba(var(--awareness-ui-text-strong-rgb), 0.96);
+  --as-topbar-title-hover-color: rgba(var(--awareness-ui-text-strong-rgb), 1);
+  --as-topbar-subtitle-color: rgba(var(--awareness-ui-text-rgb), 0.82);
+  --as-topbar-meta-color: rgba(var(--awareness-ui-text-rgb), 0.78);
+  --as-topbar-meta-author-color: rgba(var(--awareness-ui-text-rgb), 0.8);
+  --as-topbar-link-color: rgba(var(--awareness-ui-text-rgb), 0.86);
+  --as-topbar-link-hover-color: rgba(var(--awareness-ui-text-strong-rgb), 0.98);
+  --as-topbar-link-hover-bg: rgba(var(--awareness-ui-text-rgb), 0.12);
+  --as-topbar-note-divider-color: rgba(var(--awareness-ui-text-rgb), 0.26);
+  --as-topbar-note-color: rgba(var(--awareness-ui-text-rgb), 0.82);
+  --as-topbar-lang-color: rgba(var(--awareness-ui-text-strong-rgb), 0.96);
+  --as-topbar-lang-border: rgba(var(--awareness-ui-text-rgb), 0.32);
+  --as-topbar-lang-bg: rgba(var(--awareness-ui-text-rgb), 0.1);
+  --as-topbar-nav-border: rgba(var(--awareness-ui-text-rgb), 0.22);
+  --as-topbar-toggler-border: rgba(var(--awareness-ui-text-rgb), 0.55);
+  --as-topbar-toggler-focus: rgba(var(--awareness-ui-text-rgb), 0.28);
   background:
     radial-gradient(circle at 18% 18%, rgba(46, 72, 116, 0.18), transparent 38%),
     radial-gradient(circle at 78% 28%, rgba(74, 114, 179, 0.14), transparent 42%),
@@ -91,7 +91,7 @@ body.awareness-page {
   border: 1px solid rgba(var(--color-accent), 0.16);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.22);
   overflow: hidden;
-  transition: transform var(--kesson-transition-snappy), box-shadow var(--kesson-transition-snappy), border-color var(--kesson-transition-snappy);
+  transition: transform var(--ds-transition-snappy), box-shadow var(--ds-transition-snappy), border-color var(--ds-transition-snappy);
 }
 
 .img-card-media {
@@ -176,13 +176,13 @@ body.awareness-page {
 }
 
 .offcanvas-kesson {
-  --bs-offcanvas-width: var(--kesson-offcanvas-width);
-  width: var(--kesson-offcanvas-width);
-  background: var(--kesson-offcanvas-bg);
+  --bs-offcanvas-width: var(--as-offcanvas-width);
+  width: var(--as-offcanvas-width);
+  background: var(--as-offcanvas-bg);
 }
 
 .offcanvas-kesson .offcanvas-title {
-  color: var(--kesson-offcanvas-heading);
+  color: var(--as-offcanvas-heading);
   letter-spacing: 0.15em;
 }
 
@@ -195,7 +195,7 @@ body.awareness-page {
 }
 
 .offcanvas-kesson .offcanvas-body::-webkit-scrollbar-thumb {
-  background: var(--kesson-scrollbar-thumb);
+  background: var(--as-scrollbar-thumb);
   border-radius: 3px;
 }
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -4,7 +4,7 @@ body {
   overflow-x: hidden;
   overflow-y: auto;
   background: var(--color-bg-body);
-  font-family: var(--kesson-font-serif-display);
+  font-family: var(--ds-font-serif-display);
 }
 
 #canvas-container {

--- a/src/styles/dev-legacy.css
+++ b/src/styles/dev-legacy.css
@@ -1,15 +1,15 @@
 .dev-components-link {
   display: none;
   position: fixed;
-  top: calc(var(--kesson-topbar-actual-height, var(--kesson-topbar-height)) + 2.95rem);
+  top: calc(var(--as-topbar-actual-height, var(--as-topbar-height)) + 2.95rem);
   right: 0.95rem;
   z-index: 58;
   padding: 0.2rem 0.48rem;
   border-radius: 999px;
-  border: 1px solid var(--kesson-dev-hud-border);
-  background: var(--kesson-dev-hud-bg);
-  color: var(--kesson-dev-hud-text);
-  font-size: var(--kesson-dev-hud-font-size, 0.80rem);
+  border: 1px solid var(--as-dev-hud-border);
+  background: var(--as-dev-hud-bg);
+  color: var(--as-dev-hud-text);
+  font-size: var(--as-dev-hud-font-size, 0.80rem);
   letter-spacing: 0.04em;
   line-height: 1;
   font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
@@ -32,14 +32,14 @@
 
 #dev-version-inline {
   position: fixed;
-  top: calc(var(--kesson-topbar-actual-height, var(--kesson-topbar-height)) + 2.5rem);
+  top: calc(var(--as-topbar-actual-height, var(--as-topbar-height)) + 2.5rem);
   left: 1rem;
   z-index: 58;
   color: rgba(var(--color-sub-text), 0.4);
-  font-size: var(--kesson-graphic-switcher-btn, 0.88rem);
+  font-size: var(--as-graphic-switcher-btn, 0.88rem);
   letter-spacing: 0.06em;
   line-height: 1;
-  font-family: var(--kesson-font-mono-ui);
+  font-family: var(--ds-font-mono-ui);
   pointer-events: none;
   user-select: none;
   transition: opacity 0.6s ease;
@@ -59,13 +59,13 @@
   right: 0;
   transform: translateY(-50%);
   z-index: 1001;
-  background: var(--kesson-dev-toggle-bg);
+  background: var(--as-dev-toggle-bg);
   backdrop-filter: blur(8px);
-  border: 1px solid var(--kesson-dev-toggle-border);
+  border: 1px solid var(--as-dev-toggle-border);
   border-right: none;
   border-radius: 4px 0 0 4px;
-  color: var(--kesson-dev-toggle-text);
-  font-size: var(--kesson-dev-hud-font-size, 0.80rem);
+  color: var(--as-dev-toggle-text);
+  font-size: var(--as-dev-hud-font-size, 0.80rem);
   font-family: monospace;
   padding: 8px 5px;
   cursor: pointer;
@@ -75,8 +75,8 @@
 }
 
 #dev-links-toggle:hover {
-  color: var(--kesson-dev-toggle-text-hover);
-  background: var(--kesson-dev-toggle-bg-hover);
+  color: var(--as-dev-toggle-text-hover);
+  background: var(--as-dev-toggle-bg-hover);
 }
 
 .offcanvas-links {
@@ -133,7 +133,7 @@
 
 @media (max-width: 767.98px) {
   #dev-version-inline {
-    top: calc(var(--kesson-topbar-actual-height, var(--kesson-topbar-height)) + 2.1rem);
+    top: calc(var(--as-topbar-actual-height, var(--as-topbar-height)) + 2.1rem);
     left: 0.6rem;
     font-size: 0.62rem;
   }

--- a/src/styles/dev-panel.css
+++ b/src/styles/dev-panel.css
@@ -5,13 +5,13 @@
   left: auto;
   transform: translateY(-50%);
   z-index: 1001;
-  background: var(--kesson-dev-toggle-bg);
+  background: var(--as-dev-toggle-bg);
   backdrop-filter: blur(8px);
-  border: 1px solid var(--kesson-dev-toggle-border);
+  border: 1px solid var(--as-dev-toggle-border);
   border-right: none;
   border-radius: 4px 0 0 4px;
-  color: var(--kesson-dev-toggle-text);
-  font-size: var(--kesson-dev-hud-font-size, 0.80rem);
+  color: var(--as-dev-toggle-text);
+  font-size: var(--as-dev-hud-font-size, 0.80rem);
   font-family: monospace;
   padding: 8px 5px;
   cursor: pointer;
@@ -26,8 +26,8 @@
 }
 
 #dev-panel-toggle:hover {
-  color: var(--kesson-dev-toggle-text-hover);
-  background: var(--kesson-dev-toggle-bg-hover);
+  color: var(--as-dev-toggle-text-hover);
+  background: var(--as-dev-toggle-bg-hover);
 }
 
 #dev-panel {
@@ -38,8 +38,8 @@
   height: 100vh;
   z-index: 1200;
   color: #d9e5ff;
-  background: var(--kesson-dev-panel-bg);
-  border-left: 1px solid var(--kesson-dev-panel-border);
+  background: var(--as-dev-panel-bg);
+  border-left: 1px solid var(--as-dev-panel-border);
   transform: translateX(100%);
   transition: transform 0.25s ease;
   overflow: hidden;
@@ -55,14 +55,14 @@
   align-items: center;
   justify-content: space-between;
   padding: 12px 14px;
-  border-bottom: 1px solid var(--kesson-dev-panel-header-border);
+  border-bottom: 1px solid var(--as-dev-panel-header-border);
 }
 
 #dev-panel .dev-panel-title {
   margin: 0;
   font-size: 0.85rem;
   letter-spacing: 0.08em;
-  color: var(--kesson-dev-panel-title-color);
+  color: var(--as-dev-panel-title-color);
 }
 
 #dev-panel .dev-panel-header-actions {
@@ -78,12 +78,12 @@
 }
 
 #dev-panel .accordion-button {
-  background: var(--kesson-dev-panel-accordion-bg);
-  color: var(--kesson-dev-panel-accordion-text);
+  background: var(--as-dev-panel-accordion-bg);
+  color: var(--as-dev-panel-accordion-text);
 }
 
 #dev-panel .accordion-button:not(.collapsed) {
-  background: var(--kesson-dev-panel-accordion-active-bg);
+  background: var(--as-dev-panel-accordion-active-bg);
   color: #fff;
 }
 
@@ -92,13 +92,13 @@
 }
 
 #dev-panel .accordion-body {
-  background: var(--kesson-dev-panel-body-bg);
+  background: var(--as-dev-panel-body-bg);
 }
 
 #dev-panel .form-label {
   font-size: 0.72rem;
   margin-bottom: 0.25rem;
-  color: var(--kesson-dev-panel-label-color);
+  color: var(--as-dev-panel-label-color);
 }
 
 #dev-panel .form-range {
@@ -113,14 +113,14 @@
   margin: 0 0 0.75rem;
   font-size: 0.80rem;
   line-height: 1.45;
-  color: var(--kesson-dev-panel-help-color);
+  color: var(--as-dev-panel-help-color);
 }
 
 #dev-panel .dev-row-help {
   margin-top: 0.2rem;
   font-size: 0.80rem;
   line-height: 1.35;
-  color: var(--kesson-dev-panel-help-sub-color);
+  color: var(--as-dev-panel-help-sub-color);
 }
 
 #dev-panel .dev-row-meta {
@@ -132,7 +132,7 @@
 
 #dev-panel .dev-value {
   font-size: 0.72rem;
-  color: var(--kesson-dev-panel-value-color);
+  color: var(--as-dev-panel-value-color);
   min-width: 58px;
   text-align: right;
 }
@@ -145,17 +145,17 @@
 
 #dev-panel .dev-json-status {
   font-size: 0.72rem;
-  color: var(--kesson-dev-panel-status-color);
+  color: var(--as-dev-panel-status-color);
   margin-top: 6px;
   min-height: 1.2em;
 }
 
 #dev-panel .dev-panel-empty {
   padding: 12px;
-  border: 1px solid var(--kesson-dev-panel-empty-border);
+  border: 1px solid var(--as-dev-panel-empty-border);
   border-radius: 8px;
-  color: var(--kesson-dev-panel-empty-text);
-  background: var(--kesson-dev-panel-empty-bg);
+  color: var(--as-dev-panel-empty-text);
+  background: var(--as-dev-panel-empty-bg);
   font-size: 0.72rem;
 }
 

--- a/src/styles/reports.css
+++ b/src/styles/reports.css
@@ -2,9 +2,9 @@
 #reports-section {
   position: relative;
   z-index: 5;
-  --reports-font-mono: var(--kesson-font-mono-ui);
-  --reports-font-serif: var(--kesson-font-serif-ui);
-  --reports-font-sans: var(--kesson-font-sans-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
+  --reports-font-mono: var(--ds-font-mono-ui);
+  --reports-font-serif: var(--ds-font-serif-ui);
+  --reports-font-sans: var(--as-font-sans-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
   --reports-slide-btn-rgb: var(--color-accent);
   --reports-slide-btn-text: rgba(var(--color-highlight), .82);
   --reports-slide-btn-text-strong: rgba(var(--color-highlight), .94);
@@ -19,8 +19,8 @@
   --reports-panel-radius: 0.5rem;
   --reports-panel-padding: 0.9rem;
   --reports-stack-gap: 0.9rem;
-  --reports-panel-shadow: var(--kesson-card-shadow-soft);
-  --reports-panel-shadow-hover: var(--kesson-card-shadow-rich);
+  --reports-panel-shadow: var(--ds-card-shadow-soft);
+  --reports-panel-shadow-hover: var(--ds-card-shadow-rich);
   --reports-border-soft: rgba(var(--color-accent), 0.12);
   --reports-border-base: rgba(var(--color-accent), 0.2);
   --reports-border-strong: rgba(var(--color-accent), 0.35);
@@ -30,7 +30,7 @@
   --reports-text-muted: rgba(var(--color-sub-text), 0.56);
   --reports-text-bright: rgba(var(--color-highlight), 0.78);
   --reports-control-font-size: calc(0.8rem + var(--reports-font-step));
-  --reports-control-letter-spacing: var(--kesson-letter-ui-normal);
+  --reports-control-letter-spacing: var(--ds-letter-ui-normal);
   --reports-palette-1-rgb: 157, 172, 194;
   --reports-palette-2-rgb: 241, 190, 82;
   --reports-palette-3-rgb: 92, 145, 255;
@@ -76,12 +76,12 @@
   --bs-btn-active-bg: var(--reports-bg-active);
   --bs-btn-active-border-color: rgba(var(--color-accent), 0.45);
   --bs-btn-focus-shadow-rgb: var(--color-accent);
-  --bs-btn-border-radius: var(--kesson-radius-sm);
+  --bs-btn-border-radius: var(--ds-radius-sm);
   font-family: var(--reports-font-serif);
   font-size: var(--reports-control-font-size);
-  letter-spacing: var(--kesson-letter-ui-tight);
+  letter-spacing: var(--ds-letter-ui-tight);
   text-transform: none;
-  transition: border-color var(--kesson-transition-standard), background var(--kesson-transition-standard), color var(--kesson-transition-standard), box-shadow var(--kesson-transition-standard);
+  transition: border-color var(--ds-transition-standard), background var(--ds-transition-standard), color var(--ds-transition-standard), box-shadow var(--ds-transition-standard);
 }
 
 #reports-table-filters .reports-filter-btn:not([data-filter="all"]) {
@@ -108,7 +108,7 @@
 .reports-tab-content {
   border: 1px solid var(--reports-border-soft);
   border-radius: var(--reports-panel-radius);
-  background: var(--kesson-card-bg);
+  background: var(--as-card-bg);
   padding: var(--reports-panel-padding);
   box-shadow: var(--reports-panel-shadow);
 }
@@ -118,7 +118,7 @@
   cursor: pointer;
   border: 1px solid rgba(var(--color-accent), 0.18);
   background: linear-gradient(180deg, rgba(var(--color-accent), 0.12), rgba(var(--color-accent), 0.05));
-  transition: border-color var(--kesson-transition-snappy), box-shadow var(--kesson-transition-snappy), transform var(--kesson-transition-snappy), background-color var(--kesson-transition-snappy);
+  transition: border-color var(--ds-transition-snappy), box-shadow var(--ds-transition-snappy), transform var(--ds-transition-snappy), background-color var(--ds-transition-snappy);
 }
 
 .reports-feature-card:hover {
@@ -148,16 +148,16 @@
 
 .reports-subheading {
   margin: 0 0 0.65rem;
-  color: var(--kesson-topbar-link-color);
-  font-size: var(--kesson-card-title, 1.0rem);
-  letter-spacing: var(--kesson-letter-ui-heading);
-  font-family: var(--kesson-font-serif-display);
+  color: var(--as-topbar-link-color);
+  font-size: var(--ds-card-title, 1.0rem);
+  letter-spacing: var(--ds-letter-ui-heading);
+  font-family: var(--ds-font-serif-display);
   font-weight: 400;
 }
 
 .reports-ai-notice,
 .reports-level-legend {
-  color: var(--kesson-topbar-link-color);
+  color: var(--as-topbar-link-color);
   font-size: 0.875rem;
   line-height: 1.6;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -189,19 +189,19 @@
   padding: 0.72rem 1rem;
   border-color: var(--reports-border-strong);
   border-width: 1px;
-  border-radius: var(--kesson-radius-md);
+  border-radius: var(--ds-radius-md);
   background: rgba(var(--color-accent), 0.2);
   color: rgba(var(--color-highlight), 0.92);
   font-family: var(--reports-font-serif);
   font-size: clamp(calc(0.79rem + var(--reports-font-step)), calc(2.35vmin + var(--reports-font-step)), calc(0.94rem + var(--reports-font-step)));
-  letter-spacing: var(--kesson-letter-ui-tight);
+  letter-spacing: var(--ds-letter-ui-tight);
   box-shadow: 0 0 0.8rem rgba(var(--color-accent), 0.12);
 }
 
 .report-metric-card {
-  background: var(--kesson-card-bg);
-  border: 1px solid var(--kesson-card-border);
-  border-radius: var(--kesson-radius-lg);
+  background: var(--as-card-bg);
+  border: 1px solid var(--ds-card-border);
+  border-radius: var(--ds-radius-lg);
   box-shadow: var(--reports-panel-shadow);
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
@@ -210,7 +210,7 @@
 .report-metric-label {
   color: rgba(var(--color-heading), 0.5);
   font-size: calc(0.8rem + var(--reports-font-step));
-  letter-spacing: var(--kesson-letter-ui-tight);
+  letter-spacing: var(--ds-letter-ui-tight);
   font-family: var(--reports-font-serif);
 }
 
@@ -249,7 +249,7 @@
   font-family: var(--reports-font-serif);
   font-size: var(--reports-control-font-size);
   letter-spacing: var(--reports-control-letter-spacing);
-  transition: border-color var(--kesson-transition-snappy), background-color var(--kesson-transition-snappy), box-shadow var(--kesson-transition-snappy), transform var(--kesson-transition-snappy), opacity var(--kesson-transition-snappy);
+  transition: border-color var(--ds-transition-snappy), background-color var(--ds-transition-snappy), box-shadow var(--ds-transition-snappy), transform var(--ds-transition-snappy), opacity var(--ds-transition-snappy);
 }
 
 .reports-domain-item:hover {
@@ -291,7 +291,7 @@
 .reports-domain-item-name {
   color: rgba(var(--color-heading), 0.82);
   font-size: calc(0.8rem + var(--reports-font-step));
-  font-family: var(--kesson-font-serif-display);
+  font-family: var(--ds-font-serif-display);
   line-height: 1.2;
   letter-spacing: 0.03em;
   display: -webkit-box;
@@ -335,7 +335,7 @@
   text-shadow: 0 0 10px rgba(var(--reports-slide-btn-rgb), .1);
   cursor: pointer;
   touch-action: manipulation;
-  transition: border-color var(--kesson-transition-standard), background var(--kesson-transition-standard), color var(--kesson-transition-standard), box-shadow var(--kesson-transition-standard), transform var(--kesson-transition-snappy);
+  transition: border-color var(--ds-transition-standard), background var(--ds-transition-standard), color var(--ds-transition-standard), box-shadow var(--ds-transition-standard), transform var(--ds-transition-snappy);
 }
 
 .reports-slide-btn:hover,
@@ -369,7 +369,7 @@
 }
 
 .reports-md-modal-content {
-  background: var(--kesson-offcanvas-bg);
+  background: var(--as-offcanvas-bg);
   color: rgba(var(--color-heading), 0.92);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);

--- a/src/styles/shell-content.css
+++ b/src/styles/shell-content.css
@@ -2,7 +2,7 @@
 
 #graphic-switcher {
   position: fixed;
-  top: calc(var(--kesson-topbar-height) + 0.7rem);
+  top: calc(var(--as-topbar-height) + 0.7rem);
   left: 1rem;
   z-index: 58;
   display: flex;
@@ -12,8 +12,8 @@
 }
 
 .graphic-switcher-label {
-  font-family: var(--kesson-font-serif-display);
-  font-size: var(--kesson-graphic-switcher-label, 0.68rem);
+  font-family: var(--ds-font-serif-display);
+  font-size: var(--as-graphic-switcher-label, 0.68rem);
   letter-spacing: 0.08em;
   color: rgba(var(--awareness-ui-text-rgb, var(--color-sub-text)), 0.7);
   margin-right: 0.4rem;
@@ -28,8 +28,8 @@
   border-bottom: 1.5px solid transparent;
   padding: 0.2rem 0.5rem 0.22rem;
   color: rgba(var(--awareness-ui-text-rgb, var(--color-sub-text)), 0.78);
-  font-family: var(--kesson-font-serif-display);
-  font-size: var(--kesson-graphic-switcher-btn, 0.88rem);
+  font-family: var(--ds-font-serif-display);
+  font-size: var(--as-graphic-switcher-btn, 0.88rem);
   letter-spacing: 0.06em;
   cursor: pointer;
   transition: color 0.25s ease, border-color 0.25s ease;
@@ -75,7 +75,7 @@
 
 .nav-label:focus-visible,
 .nav-label.is-nav-focused {
-  outline: 2px solid var(--kesson-focus-ring);
+  outline: 2px solid var(--ds-focus-ring);
   outline-offset: 4px;
   filter: blur(0px) !important;
   text-shadow: 0 0 18px rgba(110, 160, 255, 0.72), 0 0 6px rgba(0, 0, 0, 0.85);
@@ -128,7 +128,7 @@
 }
 
 #credit .credit-signature {
-  font-size: var(--kesson-footer-signature-size, 0.80rem);
+  font-size: var(--ds-footer-signature-size, 0.80rem);
   color: rgba(150, 175, 210, 0.35);
   font-family: 'Georgia', serif;
   letter-spacing: 0.08em;
@@ -159,7 +159,7 @@ h1 {
   color: rgba(var(--awareness-hero-title-rgb, var(--color-heading)), 0.95);
   font-family: "Noto Serif JP", "Yu Mincho", "MS PMincho", serif;
   font-weight: 400;
-  font-size: var(--kesson-h1-size);
+  font-size: var(--ds-h1-size);
   letter-spacing: clamp(0.15em, 1.2vmin, 0.5em);
   line-height: 1.6;
   margin-bottom: 0.6rem;
@@ -176,18 +176,18 @@ h1 {
 }
 
 .tagline {
-  font-size: var(--kesson-overlay-tagline, 0.80rem);
+  font-size: var(--ds-overlay-tagline, 0.80rem);
   color: rgba(var(--awareness-hero-tagline-rgb, var(--color-heading)), 0.88);
-  font-family: var(--kesson-font-serif-display);
+  font-family: var(--ds-font-serif-display);
   letter-spacing: 0.05em;
   line-height: 1.8;
   text-shadow: 0 0 30px rgba(var(--color-accent), 0.3);
 }
 
 .tagline-en {
-  font-size: var(--kesson-overlay-tagline-en, 0.80rem);
+  font-size: var(--ds-overlay-tagline-en, 0.80rem);
   color: rgba(var(--awareness-hero-tagline-sub-rgb, var(--color-heading)), 0.82);
-  font-family: var(--kesson-font-serif-ui);
+  font-family: var(--ds-font-serif-ui);
   letter-spacing: 0.03em;
   line-height: 1.6;
   text-shadow: 0 0 30px rgba(var(--color-accent), 0.3);
@@ -198,7 +198,7 @@ html[lang="en"] h1 {
   letter-spacing: clamp(0.05em, 0.4vmin, 0.15em);
   line-height: 1.3;
   margin-bottom: 0.4rem;
-  font-family: var(--kesson-font-serif-ui);
+  font-family: var(--ds-font-serif-ui);
 }
 
 html[lang="en"] #taglines {
@@ -242,10 +242,10 @@ html[lang="en"] #taglines {
 #scroll-hint-top span,
 #left-kesson-link span {
   display: block;
-  font-size: var(--kesson-font-size-ui-xs, 0.80rem);
+  font-size: var(--ds-font-size-ui-xs, 0.80rem);
   color: rgba(var(--awareness-ui-text-rgb, var(--color-sub-text)), 0.7);
-  font-family: var(--kesson-font-serif-ui);
-  letter-spacing: var(--kesson-letter-ui-wide);
+  font-family: var(--ds-font-serif-ui);
+  letter-spacing: var(--ds-letter-ui-wide);
 }
 
 #scroll-hint span,
@@ -256,7 +256,7 @@ html[lang="en"] #taglines {
 #scroll-hint .arrow,
 #scroll-hint-top .arrow,
 #left-kesson-link .arrow {
-  font-size: var(--kesson-font-size-ui-arrow, clamp(0.7rem, 3.5vmin, 1.2rem));
+  font-size: var(--ds-font-size-ui-arrow, clamp(0.7rem, 3.5vmin, 1.2rem));
   color: rgba(var(--awareness-ui-text-rgb, var(--color-sub-text)), 0.62);
 }
 
@@ -283,13 +283,13 @@ html[lang="en"] #taglines {
 }
 
 #left-kesson-link:focus-visible {
-  outline: 2px solid var(--kesson-focus-ring-soft);
+  outline: 2px solid var(--ds-focus-ring-soft);
   outline-offset: 3px;
 }
 
 #scroll-hint-top {
   position: fixed;
-  top: calc(var(--kesson-topbar-actual-height, var(--kesson-topbar-height)) + 6px);
+  top: calc(var(--as-topbar-actual-height, var(--as-topbar-height)) + 6px);
   left: 50%;
   transform: translateX(-50%);
   z-index: 20;
@@ -319,7 +319,7 @@ html[lang="en"] #taglines {
 
 #control-guide {
   position: fixed;
-  top: calc(var(--kesson-topbar-actual-height, var(--kesson-topbar-height)) + 0.7rem);
+  top: calc(var(--as-topbar-actual-height, var(--as-topbar-height)) + 0.7rem);
   right: 1rem;
   z-index: 10;
   pointer-events: none;
@@ -336,10 +336,10 @@ html[lang="en"] #taglines {
 }
 
 #control-guide .guide-key {
-  font-size: var(--kesson-control-guide, 0.80rem);
+  font-size: var(--ds-control-guide, 0.80rem);
   color: rgba(var(--awareness-ui-text-strong-rgb, var(--color-sub-text)), 0.76);
-  font-family: var(--kesson-font-mono-ui);
-  letter-spacing: var(--kesson-letter-ui-tight);
+  font-family: var(--ds-font-mono-ui);
+  letter-spacing: var(--ds-letter-ui-tight);
   white-space: nowrap;
 }
 
@@ -349,10 +349,10 @@ html[lang="en"] #taglines {
 }
 
 #control-guide .guide-action {
-  font-size: var(--kesson-control-guide, 0.80rem);
+  font-size: var(--ds-control-guide, 0.80rem);
   color: rgba(var(--awareness-ui-text-rgb, var(--color-sub-text)), 0.72);
-  font-family: var(--kesson-font-serif-ui);
-  letter-spacing: var(--kesson-letter-ui-normal);
+  font-family: var(--ds-font-serif-ui);
+  letter-spacing: var(--ds-letter-ui-normal);
   white-space: nowrap;
 }
 
@@ -369,15 +369,15 @@ html[lang="en"] #taglines {
   border-radius: .5rem;
   background: rgba(20, 25, 40, 0.6);
   padding: .9rem;
-  box-shadow: var(--kesson-card-shadow-soft);
+  box-shadow: var(--ds-card-shadow-soft);
 }
 
 .card.kesson-card {
-  --bs-card-bg: var(--kesson-card-bg);
+  --bs-card-bg: var(--as-card-bg);
   background-color: var(--bs-card-bg);
   background-image: none;
   border: 1px solid rgba(var(--color-accent), 0.1);
-  transition: transform var(--kesson-transition-snappy), box-shadow var(--kesson-transition-snappy);
+  transition: transform var(--ds-transition-snappy), box-shadow var(--ds-transition-snappy);
   cursor: pointer;
 }
 
@@ -397,7 +397,7 @@ html[lang="en"] #taglines {
 
 .kesson-card .card-title {
   color: #fff;
-  font-size: var(--kesson-card-title, 1.0rem);
+  font-size: var(--ds-card-title, 1.0rem);
   font-family: 'Noto Serif JP', Georgia, serif;
 }
 
@@ -414,19 +414,19 @@ html[lang="en"] #taglines {
   bottom: 24px;
   right: 24px;
   z-index: 20;
-  --bs-btn-color: var(--kesson-action-text);
-  --bs-btn-bg: var(--kesson-action-bg);
-  --bs-btn-border-color: var(--kesson-action-border);
-  --bs-btn-hover-color: var(--kesson-action-text-hover);
-  --bs-btn-hover-bg: var(--kesson-action-bg-hover);
+  --bs-btn-color: var(--as-action-text);
+  --bs-btn-bg: var(--as-action-bg);
+  --bs-btn-border-color: var(--as-action-border);
+  --bs-btn-hover-color: var(--as-action-text-hover);
+  --bs-btn-hover-bg: var(--as-action-bg-hover);
   --bs-btn-hover-border-color: rgba(var(--color-accent), 0.32);
-  --bs-btn-active-color: var(--kesson-action-text-hover);
-  --bs-btn-active-bg: var(--kesson-action-bg-hover);
+  --bs-btn-active-color: var(--as-action-text-hover);
+  --bs-btn-active-bg: var(--as-action-bg-hover);
   --bs-btn-active-border-color: rgba(var(--color-accent), 0.36);
   --bs-btn-focus-shadow-rgb: var(--color-accent);
-  font-family: var(--kesson-font-serif-ui);
-  font-size: var(--kesson-surface-btn, 0.80rem);
-  letter-spacing: var(--kesson-letter-ui-wide);
+  font-family: var(--ds-font-serif-ui);
+  font-size: var(--ds-surface-btn, 0.80rem);
+  letter-spacing: var(--ds-letter-ui-wide);
   text-transform: uppercase;
   opacity: 0;
   pointer-events: none;
@@ -457,16 +457,16 @@ html[lang="en"] #taglines {
 .section-content-wrap {
   position: relative;
   z-index: 20;
-  padding: var(--kesson-section-content-padding);
+  padding: var(--ds-section-content-padding);
 }
 
 .section-heading {
-  font-size: var(--kesson-section-heading, 0.80rem);
+  font-size: var(--ds-section-heading, 0.80rem);
   font-weight: 400;
   color: rgba(var(--color-sub-text), 0.5);
   letter-spacing: 0.15em;
   text-transform: uppercase;
-  font-family: var(--kesson-font-mono-ui);
+  font-family: var(--ds-font-mono-ui);
   margin: 0 0 0.85rem;
   text-shadow:
     0 0 10px rgba(0, 0, 0, 1.0),
@@ -494,7 +494,7 @@ html[lang="en"] #taglines {
 }
 
 .section-heading-link:hover {
-  color: var(--kesson-topbar-link-hover-color);
+  color: var(--as-topbar-link-hover-color);
 }
 
 .section-heading-link:focus-visible {
@@ -537,18 +537,18 @@ html[lang="en"] #taglines {
 }
 
 .tech-footer-line {
-  font-size: var(--kesson-footer-line, 0.80rem);
+  font-size: var(--ds-footer-line, 0.80rem);
   color: rgba(var(--awareness-ui-text-rgb, 150, 175, 210), 0.62);
-  font-family: var(--kesson-font-mono-ui);
+  font-family: var(--ds-font-mono-ui);
   letter-spacing: 0.06em;
   line-height: 1.8;
 }
 
 .footer-signature {
   margin-top: 0.55rem;
-  font-size: var(--kesson-footer-signature-size, 0.80rem);
+  font-size: var(--ds-footer-signature-size, 0.80rem);
   color: rgba(var(--awareness-ui-text-strong-rgb, 195, 214, 241), 0.9);
-  font-family: var(--kesson-font-serif-ui);
+  font-family: var(--ds-font-serif-ui);
   letter-spacing: 0.06em;
   line-height: 1.5;
 }
@@ -596,7 +596,7 @@ html[lang="en"] #taglines {
 
 @media (max-width: 767.98px) {
   #graphic-switcher {
-    top: calc(var(--kesson-topbar-height) + 0.5rem);
+    top: calc(var(--as-topbar-height) + 0.5rem);
     left: 0.6rem;
   }
 

--- a/src/styles/slides.css
+++ b/src/styles/slides.css
@@ -17,9 +17,9 @@
   --slide-glass-border: rgba(148, 163, 184, 0.14);
   --slide-border-subtle: rgba(148, 163, 184, 0.08);
   --slide-border-medium: rgba(148, 163, 184, 0.18);
-  --slide-font-heading: var(--kesson-font-serif-display);
+  --slide-font-heading: var(--ds-font-serif-display);
   --slide-font-body: "Inter", "Noto Sans JP", system-ui, sans-serif;
-  --slide-font-mono: var(--kesson-font-mono-ui);
+  --slide-font-mono: var(--ds-font-mono-ui);
   --slide-radius: 16px;
   --slide-radius-sm: 8px;
 
@@ -178,7 +178,7 @@
 
 .slide-viewer-close:focus-visible,
 .slide-viewer-fullscreen:focus-visible {
-  outline: 2px solid var(--kesson-focus-ring, rgba(100, 150, 255, 0.86));
+  outline: 2px solid var(--ds-focus-ring, rgba(100, 150, 255, 0.86));
   outline-offset: 2px;
 }
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,13 +1,15 @@
 /*
  * pd design-system/tokens.css (--ds-*) を参照。
  * @import 失敗時は各 token の fallback で従来動作。
- * 参照: techo#126 / pd#84 / as#134
+ * 参照: techo#126 / pd#84 / as#134 / techo#128 (Phase 1b — --kesson-* 全廃)
  */
 @import url('../../../project-design/design-system/tokens.css');
 
 :root {
   /* Intentional difference vs creation-space:
      awareness-space keeps tighter UI type and stronger accent-backed action colors. */
+
+  /* === --color-* (--ds-color-* alias) === */
   --color-accent: var(--ds-color-accent, 100, 150, 255);
   --color-sub-text: var(--ds-color-sub-text, 180, 200, 230);
   --color-highlight: var(--ds-color-highlight, 220, 230, 245);
@@ -15,164 +17,134 @@
   --color-heading: var(--ds-color-heading, 255, 255, 255);
   --color-bg-body: var(--ds-color-bg-body, #050508);
 
-  --kesson-font-serif-display: var(--ds-font-serif-display, "Noto Serif JP", "Yu Mincho", "MS PMincho", serif);
-  --kesson-font-serif-ui: var(--ds-font-serif-ui, 'Georgia', "Noto Serif JP", serif);
-  --kesson-font-mono-ui: var(--ds-font-mono-ui, 'SF Mono', 'Fira Code', 'Consolas', monospace);
-  --kesson-font-size-ui-xs: var(--ds-font-size-ui-xs, 0.85rem);
-  --kesson-font-size-ui-sm: var(--ds-font-size-ui-sm, 0.88rem);
-  --kesson-font-size-ui-arrow: var(--ds-font-size-ui-arrow, clamp(0.7rem, 3.5vmin, 1.2rem));
+  /* === as 個性 (report scope) === */
   --reports-font-step: 0rem;
-  --kesson-letter-ui-tight: var(--ds-letter-ui-tight, 0.03em);
-  --kesson-letter-ui-normal: var(--ds-letter-ui-normal, 0.06em);
-  --kesson-letter-ui-wide: var(--ds-letter-ui-wide, 0.1em);
-  --kesson-letter-ui-heading: var(--ds-letter-ui-heading, 0.15em);
 
-  --kesson-radius-sm: var(--ds-radius-sm, 2px);
-  --kesson-radius-md: var(--ds-radius-md, 3px);
-  --kesson-radius-lg: var(--ds-radius-lg, 4px);
-  --kesson-transition-standard: var(--ds-transition-standard, 0.3s ease);
-  --kesson-transition-snappy: var(--ds-transition-snappy, 0.2s ease);
-
-  --kesson-focus-ring: var(--ds-focus-ring, rgba(var(--color-accent), 0.86));
-  --kesson-focus-ring-soft: var(--ds-focus-ring-soft, rgba(var(--color-accent), 0.8));
-  --kesson-ui-label-color: var(--ds-ui-label-color, rgba(var(--color-sub-text), 0.3));
-  --kesson-ui-arrow-color: var(--ds-ui-arrow-color, rgba(var(--color-sub-text), 0.25));
-  --kesson-ui-label-hover-color: var(--ds-ui-label-hover-color, rgba(var(--color-sub-text), 0.6));
-  --kesson-action-bg: rgba(var(--color-accent), 0.1);
-  --kesson-action-border: rgba(var(--color-accent), 0.2);
-  --kesson-action-text: rgba(var(--color-sub-text), 0.5);
-  --kesson-action-bg-hover: rgba(var(--color-accent), 0.2);
-  --kesson-action-text-hover: rgba(var(--color-highlight), 0.7);
-  --kesson-card-border: var(--ds-card-border, rgba(var(--color-accent), 0.1));
-  --kesson-card-border-strong: var(--ds-card-border-strong, rgba(var(--color-accent), 0.28));
-  --kesson-card-shadow-soft: var(--ds-card-shadow-soft, 0 4px 12px rgba(var(--color-accent), 0.15));
-  --kesson-card-shadow-rich: var(--ds-card-shadow-rich, 0 8px 24px rgba(0, 0, 0, 0.38), 0 0 12px rgba(var(--color-accent), 0.15));
-  --kesson-error-color: var(--ds-error-color, #f87171);
-  --kesson-error-size: var(--ds-error-size, 0.8rem);
-  --kesson-scrollbar-thumb: #1e293b;
-
-  --kesson-offcanvas-text: #94a3b8;
-  --kesson-offcanvas-heading: #e2e8f0;
-  --kesson-offcanvas-link: #f59e0b;
-  --kesson-viewer-overlay-closed: rgba(5, 10, 20, 0);
-  --kesson-viewer-overlay-open: rgba(5, 10, 20, 0.5);
-  --kesson-viewer-glass-bg: rgba(12, 18, 30, 0.88);
-  --kesson-viewer-glass-border: rgba(var(--color-accent), 0.06);
-
-  --kesson-md-provenance: rgba(140, 160, 200, 0.4);
-  --kesson-md-h1: rgba(240, 245, 255, 0.92);
-  --kesson-md-h1-strong: rgba(240, 245, 255, 0.95);
-  --kesson-md-h2: rgba(230, 240, 255, 0.88);
-  --kesson-md-h3: rgba(220, 230, 250, 0.85);
-  --kesson-md-h4: rgba(210, 225, 245, 0.8);
-  --kesson-md-link: rgba(var(--color-link), 0.85);
-  --kesson-md-link-hover: rgba(160, 195, 255, 1);
-  --kesson-md-quote: rgba(200, 215, 240, 0.7);
-  --kesson-md-inline-code: rgba(180, 210, 255, 0.85);
-  --kesson-md-inline-code-bg: rgba(60, 90, 150, 0.12);
-  --kesson-md-table-head-bg: rgba(40, 60, 100, 0.2);
-  --kesson-md-table-head-text: rgba(220, 230, 250, 0.9);
-  --kesson-md-table-cell-text: rgba(200, 215, 240, 0.75);
-  --kesson-md-strong: rgba(240, 245, 255, 0.95);
-  --kesson-md-em: rgba(200, 215, 240, 0.8);
-  --kesson-md-pre-bg: rgba(8, 12, 24, 0.6);
-  --kesson-md-pdf-link: rgba(160, 185, 240, 0.7);
-  --kesson-md-pdf-link-hover: rgba(200, 220, 255, 0.9);
-  --kesson-md-pdf-link-hover-bg: rgba(60, 90, 150, 0.1);
-  --kesson-viewer-glass-shadow:
-    0 0 60px rgba(0, 0, 0, 0.4),
-    0 0 120px rgba(30, 60, 120, 0.1),
-    inset 0 0 60px rgba(20, 40, 80, 0.05);
-  --kesson-viewer-x-handle: rgba(200, 215, 245, 0.7);
-
-  --kesson-dev-toggle-bg: rgba(20, 30, 50, 0.7);
-  --kesson-dev-toggle-bg-hover: rgba(30, 45, 70, 0.82);
-  --kesson-dev-toggle-border: rgba(var(--color-accent), 0.15);
-  --kesson-dev-toggle-text: rgba(180, 200, 255, 0.75);
-  --kesson-dev-toggle-text-hover: rgba(210, 225, 255, 0.95);
-  --kesson-dev-panel-bg: rgba(7, 12, 24, 0.96);
-  --kesson-dev-panel-border: rgba(140, 178, 255, 0.3);
-  --kesson-dev-panel-header-border: rgba(140, 178, 255, 0.25);
-  --kesson-dev-panel-title-color: rgba(223, 236, 255, 0.95);
-  --kesson-dev-panel-accordion-bg: rgba(26, 40, 70, 0.5);
-  --kesson-dev-panel-accordion-text: rgba(222, 235, 255, 0.92);
-  --kesson-dev-panel-accordion-active-bg: rgba(46, 72, 116, 0.7);
-  --kesson-dev-panel-body-bg: rgba(11, 20, 38, 0.75);
-  --kesson-dev-panel-label-color: rgba(188, 211, 245, 0.95);
-  --kesson-dev-panel-help-color: rgba(176, 201, 238, 0.82);
-  --kesson-dev-panel-help-sub-color: rgba(162, 188, 228, 0.72);
-  --kesson-dev-panel-value-color: rgba(201, 221, 255, 0.86);
-  --kesson-dev-panel-status-color: rgba(201, 221, 255, 0.8);
-  --kesson-dev-panel-empty-bg: rgba(11, 20, 38, 0.6);
-  --kesson-dev-panel-empty-border: rgba(140, 178, 255, 0.25);
-  --kesson-dev-panel-empty-text: rgba(201, 221, 255, 0.85);
-  --kesson-dev-hud-border: rgba(120, 164, 235, 0.42);
-  --kesson-dev-hud-bg: rgba(8, 14, 26, 0.84);
-  --kesson-dev-hud-text: rgba(205, 224, 255, 0.92);
-  --kesson-dev-hud-btn-border: rgba(130, 170, 240, 0.45);
-  --kesson-dev-hud-btn-bg: rgba(100, 152, 246, 0.2);
-  --kesson-dev-hud-btn-text: rgba(238, 246, 255, 0.96);
-  --kesson-dev-hud-btn-bg-hover: rgba(116, 165, 244, 0.32);
-  --kesson-dev-hud-input-border: rgba(130, 170, 240, 0.35);
-  --kesson-dev-hud-input-bg: rgba(10, 18, 32, 0.88);
-  --kesson-dev-hud-input-text: rgba(220, 235, 255, 0.95);
-
-  --kesson-section-content-padding: var(--ds-section-content-padding, 1rem 1.5rem 0);
-  --kesson-section-grid-margin-top: 1.5rem;
-  --kesson-card-bg: rgba(20, 25, 40, 0.9);
-  --kesson-offcanvas-width: 85%;
-  --kesson-offcanvas-bg: rgba(10, 14, 26, 0.98);
-
-  --kesson-topbar-main-title-size: clamp(0.96rem, 1.85vw, 1.38rem);
-  --kesson-topbar-main-title-size-sm: 0.86rem;
-  --kesson-topbar-title-size: clamp(0.88rem, 1.1vw, 0.96rem);
-  --kesson-topbar-subtitle-size: var(--kesson-topbar-title-size);
-  --kesson-topbar-subtitle-size-md: 0.80rem;
-  --kesson-topbar-link-size: 0.80rem;
-  --kesson-topbar-note-size: 0.80rem;
-  --kesson-topbar-note-size-sm: var(--kesson-topbar-note-size);
-  --kesson-topbar-credit-size: 0.80rem;
-  --kesson-topbar-meta-size: 0.80rem;
-  --kesson-topbar-meta-author-size: 0.80rem;
-  --kesson-topbar-bg-start: rgba(10, 14, 24, var(--kesson-topbar-alpha-strong));
-  --kesson-topbar-bg-end: rgba(10, 14, 24, var(--kesson-topbar-alpha-soft));
-  --kesson-topbar-border-color: rgba(130, 170, 240, var(--kesson-topbar-border-alpha));
-  --kesson-topbar-divider-color: rgba(170, 192, 228, 0.42);
-  --kesson-topbar-title-color: rgba(228, 238, 255, 0.92);
-  --kesson-topbar-title-hover-color: rgba(242, 248, 255, 1);
-  --kesson-topbar-subtitle-color: rgba(205, 220, 244, 0.76);
-  --kesson-topbar-meta-color: rgba(186, 204, 234, 0.72);
-  --kesson-topbar-meta-author-color: rgba(184, 203, 234, 0.74);
-  --kesson-topbar-link-color: rgba(205, 220, 244, 0.78);
-  --kesson-topbar-link-hover-color: rgba(236, 244, 255, 0.98);
-  --kesson-topbar-link-hover-bg: rgba(120, 165, 240, 0.2);
-  --kesson-topbar-note-divider-color: rgba(130, 170, 240, 0.2);
-  --kesson-topbar-note-color: rgba(165, 214, 255, 0.74);
-  --kesson-topbar-lang-color: rgba(218, 232, 255, 0.9);
-  --kesson-topbar-lang-border: rgba(130, 170, 240, 0.25);
-  --kesson-topbar-lang-bg: rgba(70, 102, 160, 0.16);
-  --kesson-topbar-nav-bg: rgba(9, 13, 24, 0.82);
-  --kesson-topbar-nav-border: rgba(130, 170, 240, 0.2);
-  --kesson-topbar-toggler-border: rgba(145, 178, 242, 0.55);
-  --kesson-topbar-toggler-focus: rgba(140, 180, 252, 0.35);
-
-  --kesson-section-heading: var(--ds-section-heading, 0.88rem);
-  --kesson-card-title: var(--ds-card-title, 1.0rem);
-  --kesson-card-text: var(--ds-card-text, 0.92rem);
-  --kesson-card-summary: var(--ds-card-summary, 0.92rem);
-  --kesson-overlay-tagline: var(--ds-overlay-tagline, 0.92rem);
-  --kesson-overlay-tagline-en: var(--ds-overlay-tagline-en, 0.88rem);
-  --kesson-control-guide: var(--ds-control-guide, 0.82rem);
-  --kesson-footer-line: var(--ds-footer-line, 0.82rem);
-  --kesson-surface-btn: var(--ds-surface-btn, 0.88rem);
-  --kesson-dev-hud-font-size: 0.80rem;
-  --kesson-footer-signature-size: var(--ds-footer-signature-size, 0.88rem);
-  --kesson-topbar-height: 3.25rem;
-  --kesson-topbar-alpha-strong: 0.10;
-  --kesson-topbar-alpha-soft: 0.10;
-  --kesson-topbar-border-alpha: 0.22;
-  --kesson-topbar-shadow-alpha: 0.26;
-  --kesson-topbar-blur: 14px;
-  --kesson-topbar-saturate: 145%;
-  --kesson-h1-size: var(--ds-h1-size, clamp(1.0rem, 5.5vmin, 2.0rem));
+  /* === --as-* (旧 --kesson-* 取り込み, see techo#128 Phase 1b) === */
+  /* --- action-* --- */
+  --as-action-bg-hover: rgba(var(--color-accent), 0.2);
+  --as-action-bg: rgba(var(--color-accent), 0.1);
+  --as-action-border: rgba(var(--color-accent), 0.2);
+  --as-action-text-hover: rgba(var(--color-highlight), 0.7);
+  --as-action-text: rgba(var(--color-sub-text), 0.5);
+  /* --- card-* --- */
+  --as-card-bg: rgba(20, 25, 40, 0.9);
+  /* --- dev-hud-* --- */
+  --as-dev-hud-bg: rgba(8, 14, 26, 0.84);
+  --as-dev-hud-border: rgba(120, 164, 235, 0.42);
+  --as-dev-hud-btn-bg-hover: rgba(116, 165, 244, 0.32);
+  --as-dev-hud-btn-bg: rgba(100, 152, 246, 0.2);
+  --as-dev-hud-btn-border: rgba(130, 170, 240, 0.45);
+  --as-dev-hud-btn-text: rgba(238, 246, 255, 0.96);
+  --as-dev-hud-font-size: 0.80rem;
+  --as-dev-hud-input-bg: rgba(10, 18, 32, 0.88);
+  --as-dev-hud-input-border: rgba(130, 170, 240, 0.35);
+  --as-dev-hud-input-text: rgba(220, 235, 255, 0.95);
+  --as-dev-hud-text: rgba(205, 224, 255, 0.92);
+  /* --- dev-panel-* --- */
+  --as-dev-panel-accordion-active-bg: rgba(46, 72, 116, 0.7);
+  --as-dev-panel-accordion-bg: rgba(26, 40, 70, 0.5);
+  --as-dev-panel-accordion-text: rgba(222, 235, 255, 0.92);
+  --as-dev-panel-bg: rgba(7, 12, 24, 0.96);
+  --as-dev-panel-body-bg: rgba(11, 20, 38, 0.75);
+  --as-dev-panel-border: rgba(140, 178, 255, 0.3);
+  --as-dev-panel-empty-bg: rgba(11, 20, 38, 0.6);
+  --as-dev-panel-empty-border: rgba(140, 178, 255, 0.25);
+  --as-dev-panel-empty-text: rgba(201, 221, 255, 0.85);
+  --as-dev-panel-header-border: rgba(140, 178, 255, 0.25);
+  --as-dev-panel-help-color: rgba(176, 201, 238, 0.82);
+  --as-dev-panel-help-sub-color: rgba(162, 188, 228, 0.72);
+  --as-dev-panel-label-color: rgba(188, 211, 245, 0.95);
+  --as-dev-panel-status-color: rgba(201, 221, 255, 0.8);
+  --as-dev-panel-title-color: rgba(223, 236, 255, 0.95);
+  --as-dev-panel-value-color: rgba(201, 221, 255, 0.86);
+  /* --- dev-toggle-* --- */
+  --as-dev-toggle-bg-hover: rgba(30, 45, 70, 0.82);
+  --as-dev-toggle-bg: rgba(20, 30, 50, 0.7);
+  --as-dev-toggle-border: rgba(var(--color-accent), 0.15);
+  --as-dev-toggle-text-hover: rgba(210, 225, 255, 0.95);
+  --as-dev-toggle-text: rgba(180, 200, 255, 0.75);
+  /* --- md-* --- */
+  --as-md-em: rgba(200, 215, 240, 0.8);
+  --as-md-h1-strong: rgba(240, 245, 255, 0.95);
+  --as-md-h1: rgba(240, 245, 255, 0.92);
+  --as-md-h2: rgba(230, 240, 255, 0.88);
+  --as-md-h3: rgba(220, 230, 250, 0.85);
+  --as-md-h4: rgba(210, 225, 245, 0.8);
+  --as-md-inline-code-bg: rgba(60, 90, 150, 0.12);
+  --as-md-inline-code: rgba(180, 210, 255, 0.85);
+  --as-md-link-hover: rgba(160, 195, 255, 1);
+  --as-md-link: rgba(var(--color-link), 0.85);
+  --as-md-pdf-link-hover-bg: rgba(60, 90, 150, 0.1);
+  --as-md-pdf-link-hover: rgba(200, 220, 255, 0.9);
+  --as-md-pdf-link: rgba(160, 185, 240, 0.7);
+  --as-md-pre-bg: rgba(8, 12, 24, 0.6);
+  --as-md-provenance: rgba(140, 160, 200, 0.4);
+  --as-md-quote: rgba(200, 215, 240, 0.7);
+  --as-md-strong: rgba(240, 245, 255, 0.95);
+  --as-md-table-cell-text: rgba(200, 215, 240, 0.75);
+  --as-md-table-head-bg: rgba(40, 60, 100, 0.2);
+  --as-md-table-head-text: rgba(220, 230, 250, 0.9);
+  /* --- offcanvas-* --- */
+  --as-offcanvas-bg: rgba(10, 14, 26, 0.98);
+  --as-offcanvas-heading: #e2e8f0;
+  --as-offcanvas-link: #f59e0b;
+  --as-offcanvas-text: #94a3b8;
+  --as-offcanvas-width: 85%;
+  /* --- scrollbar-* --- */
+  --as-scrollbar-thumb: #1e293b;
+  /* --- section-* --- */
+  --as-section-grid-margin-top: 1.5rem;
+  /* --- topbar-* --- */
+  --as-topbar-alpha-soft: 0.10;
+  --as-topbar-alpha-strong: 0.10;
+  --as-topbar-bg-end: rgba(10, 14, 24, var(--as-topbar-alpha-soft));
+  --as-topbar-bg-start: rgba(10, 14, 24, var(--as-topbar-alpha-strong));
+  --as-topbar-blur: 14px;
+  --as-topbar-border-alpha: 0.22;
+  --as-topbar-border-color: rgba(130, 170, 240, var(--as-topbar-border-alpha));
+  --as-topbar-credit-size: 0.80rem;
+  --as-topbar-divider-color: rgba(170, 192, 228, 0.42);
+  --as-topbar-height: 3.25rem;
+  --as-topbar-lang-bg: rgba(70, 102, 160, 0.16);
+  --as-topbar-lang-border: rgba(130, 170, 240, 0.25);
+  --as-topbar-lang-color: rgba(218, 232, 255, 0.9);
+  --as-topbar-link-color: rgba(205, 220, 244, 0.78);
+  --as-topbar-link-hover-bg: rgba(120, 165, 240, 0.2);
+  --as-topbar-link-hover-color: rgba(236, 244, 255, 0.98);
+  --as-topbar-link-size: 0.80rem;
+  --as-topbar-main-title-size-sm: 0.86rem;
+  --as-topbar-main-title-size: clamp(0.96rem, 1.85vw, 1.38rem);
+  --as-topbar-meta-author-color: rgba(184, 203, 234, 0.74);
+  --as-topbar-meta-author-size: 0.80rem;
+  --as-topbar-meta-color: rgba(186, 204, 234, 0.72);
+  --as-topbar-meta-size: 0.80rem;
+  --as-topbar-nav-bg: rgba(9, 13, 24, 0.82);
+  --as-topbar-nav-border: rgba(130, 170, 240, 0.2);
+  --as-topbar-note-color: rgba(165, 214, 255, 0.74);
+  --as-topbar-note-divider-color: rgba(130, 170, 240, 0.2);
+  --as-topbar-note-size-sm: var(--as-topbar-note-size);
+  --as-topbar-note-size: 0.80rem;
+  --as-topbar-saturate: 145%;
+  --as-topbar-shadow-alpha: 0.26;
+  --as-topbar-subtitle-color: rgba(205, 220, 244, 0.76);
+  --as-topbar-subtitle-size-md: 0.80rem;
+  --as-topbar-subtitle-size: var(--as-topbar-title-size);
+  --as-topbar-title-color: rgba(228, 238, 255, 0.92);
+  --as-topbar-title-hover-color: rgba(242, 248, 255, 1);
+  --as-topbar-title-size: clamp(0.88rem, 1.1vw, 0.96rem);
+  --as-topbar-toggler-border: rgba(145, 178, 242, 0.55);
+  --as-topbar-toggler-focus: rgba(140, 180, 252, 0.35);
+  /* --- viewer-* --- */
+  --as-viewer-glass-bg: rgba(12, 18, 30, 0.88);
+  --as-viewer-glass-border: rgba(var(--color-accent), 0.06);
+  --as-viewer-glass-shadow: 0 0 60px rgba(0, 0, 0, 0.4), 0 0 120px rgba(30, 60, 120, 0.1), inset 0 0 60px rgba(20, 40, 80, 0.05);
+  --as-viewer-overlay-closed: rgba(5, 10, 20, 0);
+  --as-viewer-overlay-open: rgba(5, 10, 20, 0.5);
+  --as-viewer-x-handle: rgba(200, 215, 245, 0.7);
+  /* --- font-* --- */
+  --as-font-sans-ui: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", "Meiryo", system-ui, sans-serif;
+  /* --- graphic-switcher-* --- */
+  --as-graphic-switcher-btn: 0.88rem;
+  --as-graphic-switcher-label: 0.88rem;
 }

--- a/src/styles/topbar.css
+++ b/src/styles/topbar.css
@@ -3,23 +3,23 @@
   top: 0;
   left: 0;
   width: 100%;
-  min-height: var(--kesson-topbar-height);
+  min-height: var(--as-topbar-height);
   z-index: 60;
   background: linear-gradient(
     to bottom,
-    var(--kesson-topbar-bg-start) 0%,
-    var(--kesson-topbar-bg-end) 100%
+    var(--as-topbar-bg-start) 0%,
+    var(--as-topbar-bg-end) 100%
   );
-  border-bottom: 1px solid var(--kesson-topbar-border-color);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, var(--kesson-topbar-shadow-alpha));
-  backdrop-filter: blur(var(--kesson-topbar-blur)) saturate(var(--kesson-topbar-saturate));
-  -webkit-backdrop-filter: blur(var(--kesson-topbar-blur)) saturate(var(--kesson-topbar-saturate));
+  border-bottom: 1px solid var(--as-topbar-border-color);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, var(--as-topbar-shadow-alpha));
+  backdrop-filter: blur(var(--as-topbar-blur)) saturate(var(--as-topbar-saturate));
+  -webkit-backdrop-filter: blur(var(--as-topbar-blur)) saturate(var(--as-topbar-saturate));
   padding-top: 0;
   padding-bottom: 0;
 }
 
 #kesson-topbar .container-fluid {
-  min-height: var(--kesson-topbar-height);
+  min-height: var(--as-topbar-height);
 }
 
 #kesson-topbar .topbar-brand-wrap {
@@ -34,9 +34,9 @@
 }
 
 #kesson-topbar .topbar-main-title {
-  color: var(--kesson-topbar-title-color);
-  font-family: var(--kesson-font-serif-display);
-  font-size: var(--kesson-topbar-main-title-size);
+  color: var(--as-topbar-title-color);
+  font-family: var(--ds-font-serif-display);
+  font-size: var(--as-topbar-main-title-size);
   letter-spacing: 0.04em;
   line-height: 1;
   text-transform: none;
@@ -48,13 +48,13 @@
 
 #kesson-topbar .topbar-main-title:hover,
 #kesson-topbar .topbar-main-title:focus-visible {
-  color: var(--kesson-topbar-title-hover-color);
+  color: var(--as-topbar-title-hover-color);
 }
 
 #kesson-topbar .topbar-subtitle {
-  font-size: var(--kesson-topbar-subtitle-size);
-  color: var(--kesson-topbar-subtitle-color);
-  letter-spacing: var(--kesson-letter-ui-wide);
+  font-size: var(--as-topbar-subtitle-size);
+  color: var(--as-topbar-subtitle-color);
+  letter-spacing: var(--ds-letter-ui-wide);
   line-height: 1;
   text-transform: none;
   flex: 0 0 auto;
@@ -64,7 +64,7 @@
 #kesson-topbar .topbar-subtitle::before,
 #kesson-topbar .topbar-meta::before {
   content: '·';
-  color: var(--kesson-topbar-divider-color);
+  color: var(--as-topbar-divider-color);
   margin-right: 0.45rem;
 }
 
@@ -72,23 +72,23 @@
   display: block;
   flex: 0 0 auto;
   padding: 0;
-  font-size: var(--kesson-topbar-meta-size);
+  font-size: var(--as-topbar-meta-size);
   line-height: 1;
   letter-spacing: 0.05em;
-  color: var(--kesson-topbar-meta-color);
-  font-family: var(--kesson-font-serif-ui);
+  color: var(--as-topbar-meta-color);
+  font-family: var(--ds-font-serif-ui);
   pointer-events: none;
 }
 
 #kesson-topbar .topbar-meta--author {
-  font-size: var(--kesson-topbar-meta-author-size);
-  color: var(--kesson-topbar-meta-author-color);
+  font-size: var(--as-topbar-meta-author-size);
+  color: var(--as-topbar-meta-author-color);
 }
 
 #kesson-topbar .topbar-link {
-  color: var(--kesson-topbar-link-color);
-  font-family: var(--kesson-font-mono-ui);
-  font-size: var(--kesson-topbar-link-size);
+  color: var(--as-topbar-link-color);
+  font-family: var(--ds-font-mono-ui);
+  font-size: var(--as-topbar-link-size);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   padding: 0.4rem 0.72rem;
@@ -98,8 +98,8 @@
 
 #kesson-topbar .topbar-link:hover,
 #kesson-topbar .topbar-link:focus-visible {
-  color: var(--kesson-topbar-link-hover-color);
-  background: var(--kesson-topbar-link-hover-bg);
+  color: var(--as-topbar-link-hover-color);
+  background: var(--as-topbar-link-hover-bg);
 }
 
 #kesson-topbar .topbar-link-btn {
@@ -111,28 +111,28 @@
 }
 
 #kesson-topbar .topbar-lang-btn {
-  color: var(--kesson-topbar-lang-color);
-  border: 1px solid var(--kesson-topbar-lang-border);
-  background: var(--kesson-topbar-lang-bg);
+  color: var(--as-topbar-lang-color);
+  border: 1px solid var(--as-topbar-lang-border);
+  background: var(--as-topbar-lang-bg);
 }
 
 #kesson-topbar .topbar-collab-item {
   margin-left: 0.45rem;
   padding-left: 0.55rem;
-  border-left: 1px solid var(--kesson-topbar-note-divider-color);
+  border-left: 1px solid var(--as-topbar-note-divider-color);
 }
 
 #kesson-topbar .topbar-collab-note {
   display: inline-block;
-  font-family: var(--kesson-font-serif-ui);
-  font-size: var(--kesson-topbar-note-size);
+  font-family: var(--ds-font-serif-ui);
+  font-size: var(--as-topbar-note-size);
   line-height: 1;
-  letter-spacing: var(--kesson-letter-ui-normal);
-  color: var(--kesson-topbar-note-color);
+  letter-spacing: var(--ds-letter-ui-normal);
+  color: var(--as-topbar-note-color);
   white-space: nowrap;
   margin-left: 0.5rem;
   padding-left: 0.56rem;
-  border-left: 1px solid var(--kesson-topbar-note-divider-color);
+  border-left: 1px solid var(--as-topbar-note-divider-color);
   min-width: 0;
   max-width: min(42vw, 18rem);
   overflow: hidden;
@@ -146,19 +146,19 @@
 }
 
 .topbar-font-btn {
-  font-family: var(--kesson-font-mono-ui);
-  font-size: var(--kesson-topbar-credit-size, 0.80rem);
+  font-family: var(--ds-font-mono-ui);
+  font-size: var(--as-topbar-credit-size, 0.80rem);
   letter-spacing: 0.08em;
   padding: 0.2rem 0.5rem;
   background: transparent;
-  border: 1px solid var(--kesson-topbar-nav-border);
-  color: var(--kesson-topbar-link-color);
+  border: 1px solid var(--as-topbar-nav-border);
+  color: var(--as-topbar-link-color);
   line-height: 1.4;
 }
 
 .topbar-font-btn:hover:not(:disabled) {
-  background: var(--kesson-topbar-link-hover-bg);
-  color: var(--kesson-topbar-link-hover-color);
+  background: var(--as-topbar-link-hover-bg);
+  color: var(--as-topbar-link-hover-color);
 }
 
 .topbar-font-btn:disabled {
@@ -167,13 +167,13 @@
 }
 
 #kesson-topbar .topbar-toggler {
-  border-color: var(--kesson-topbar-toggler-border);
+  border-color: var(--as-topbar-toggler-border);
   padding: 0.18rem 0.44rem;
-  color: var(--kesson-topbar-link-color);
+  color: var(--as-topbar-link-color);
 }
 
 #kesson-topbar .topbar-toggler:focus {
-  box-shadow: 0 0 0 0.14rem var(--kesson-topbar-toggler-focus);
+  box-shadow: 0 0 0 0.14rem var(--as-topbar-toggler-focus);
 }
 
 #kesson-topbar .navbar-toggler-icon {
@@ -190,8 +190,8 @@
   margin-top: 0.35rem;
   padding: 0.35rem 0.2rem 0.5rem;
   border-radius: 0.6rem;
-  background: var(--kesson-topbar-nav-bg);
-  border: 1px solid var(--kesson-topbar-nav-border);
+  background: var(--as-topbar-nav-bg);
+  border: 1px solid var(--as-topbar-nav-border);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
 }
@@ -222,7 +222,7 @@
   }
 
   #kesson-topbar .topbar-subtitle {
-    font-size: var(--kesson-topbar-subtitle-size-md);
+    font-size: var(--as-topbar-subtitle-size-md);
   }
 }
 
@@ -232,11 +232,11 @@
   }
 
   #kesson-topbar .topbar-main-title {
-    font-size: var(--kesson-topbar-main-title-size-sm);
+    font-size: var(--as-topbar-main-title-size-sm);
   }
 
   #kesson-topbar .topbar-collab-note {
-    font-size: var(--kesson-topbar-credit-size);
+    font-size: var(--as-topbar-credit-size);
     letter-spacing: 0.05em;
     margin-left: 0.36rem;
     padding-left: 0.36rem;

--- a/src/styles/viewer.css
+++ b/src/styles/viewer.css
@@ -7,14 +7,14 @@
 }
 
 .offcanvas-body::-webkit-scrollbar-thumb {
-  background: var(--kesson-scrollbar-thumb);
+  background: var(--as-scrollbar-thumb);
   border-radius: 3px;
 }
 
 .offcanvas-kesson {
-  --bs-offcanvas-width: var(--kesson-offcanvas-width);
-  width: var(--kesson-offcanvas-width);
-  background: var(--kesson-offcanvas-bg);
+  --bs-offcanvas-width: var(--as-offcanvas-width);
+  width: var(--as-offcanvas-width);
+  background: var(--as-offcanvas-bg);
 }
 
 .md-article {
@@ -30,34 +30,34 @@
 
 .md-body h1 {
   font-size: 1.2rem;
-  color: var(--kesson-md-h1);
+  color: var(--as-md-h1);
   margin: 2rem 0 0.8rem;
   line-height: 1.4;
 }
 
 .md-body h1:first-child {
   font-size: 1.3rem;
-  color: var(--kesson-md-h1-strong);
+  color: var(--as-md-h1-strong);
   margin-top: 0;
   margin-bottom: 1.2rem;
 }
 
 .md-body h2 {
   font-size: 1.05rem;
-  color: var(--kesson-md-h2);
+  color: var(--as-md-h2);
   margin: 1.8rem 0 0.7rem;
   line-height: 1.4;
 }
 
 .md-body h3 {
   font-size: 0.95rem;
-  color: var(--kesson-md-h3);
+  color: var(--as-md-h3);
   margin: 1.4rem 0 0.5rem;
 }
 
 .md-body h4 {
   font-size: 0.9rem;
-  color: var(--kesson-md-h4);
+  color: var(--as-md-h4);
   margin: 1.2rem 0 0.4rem;
 }
 
@@ -71,7 +71,7 @@
   border-left: 2px solid rgba(var(--color-accent), 0.15);
   padding-left: 1em;
   margin: 1em 0;
-  color: var(--kesson-md-quote);
+  color: var(--as-md-quote);
   font-style: italic;
 }
 
@@ -82,20 +82,20 @@
 }
 
 .md-body a:hover {
-  color: var(--kesson-md-link-hover);
+  color: var(--as-md-link-hover);
 }
 
 .md-body strong {
-  color: var(--kesson-md-strong);
+  color: var(--as-md-strong);
   font-weight: 600;
 }
 
 .md-body em {
-  color: var(--kesson-md-em);
+  color: var(--as-md-em);
 }
 
 .md-body pre {
-  background: var(--kesson-md-pre-bg);
+  background: var(--as-md-pre-bg);
   border: 1px solid rgba(var(--color-accent), 0.08);
   border-radius: 3px;
   padding: 1em 1.2em;
@@ -119,8 +119,8 @@
 .md-body code {
   font-family: 'SF Mono', 'Consolas', 'Monaco', 'Menlo', monospace;
   font-size: 0.85em;
-  color: var(--kesson-md-inline-code);
-  background: var(--kesson-md-inline-code-bg);
+  color: var(--as-md-inline-code);
+  background: var(--as-md-inline-code-bg);
   padding: 0.15em 0.4em;
   border-radius: 2px;
 }
@@ -157,13 +157,13 @@
 }
 
 .md-body th {
-  background: var(--kesson-md-table-head-bg);
-  color: var(--kesson-md-table-head-text);
+  background: var(--as-md-table-head-bg);
+  color: var(--as-md-table-head-text);
   font-weight: 500;
 }
 
 .md-body td {
-  color: var(--kesson-md-table-cell-text);
+  color: var(--as-md-table-cell-text);
 }
 
 .md-body img {

--- a/src/ui/font-size-ctrl.js
+++ b/src/ui/font-size-ctrl.js
@@ -10,43 +10,43 @@ const MIGRATION_KEY = 'kesson-font-step-v5';
 
 // Global UI font sizes (shell.css :root)
 const FONT_VARS = {
-    '--kesson-font-size-ui-xs': 0.80,
-    '--kesson-font-size-ui-sm': 0.80,
+    '--ds-font-size-ui-xs': 0.80,
+    '--ds-font-size-ui-sm': 0.80,
 };
 
 const CLASS_VARS = {
     // -- Card & section --
-    '--kesson-section-heading': 0.80,
-    '--kesson-card-title': 0.80,
-    '--kesson-card-text': 0.80,
-    '--kesson-card-summary': 0.80,
+    '--ds-section-heading': 0.80,
+    '--ds-card-title': 0.80,
+    '--ds-card-text': 0.80,
+    '--ds-card-summary': 0.80,
 
     // -- Overlay & guide --
-    '--kesson-overlay-tagline': 0.80,
-    '--kesson-overlay-tagline-en': 0.80,
-    '--kesson-control-guide': 0.80,
-    '--kesson-surface-btn': 0.80,
+    '--ds-overlay-tagline': 0.80,
+    '--ds-overlay-tagline-en': 0.80,
+    '--ds-control-guide': 0.80,
+    '--ds-surface-btn': 0.80,
 
     // -- Footer --
-    '--kesson-footer-line': 0.80,
-    '--kesson-footer-signature-size': 0.80,
+    '--ds-footer-line': 0.80,
+    '--ds-footer-signature-size': 0.80,
 
     // -- Dev HUD --
-    '--kesson-dev-hud-font-size': 0.80,
+    '--as-dev-hud-font-size': 0.80,
 
     // -- Topbar --
-    '--kesson-topbar-link-size': 0.80,
-    '--kesson-topbar-credit-size': 0.80,
-    '--kesson-topbar-note-size': 0.80,
-    '--kesson-topbar-meta-size': 0.80,
-    '--kesson-topbar-meta-author-size': 0.80,
-    '--kesson-topbar-subtitle-size-md': 0.80,
-    '--kesson-topbar-title-size': 0.80,
-    '--kesson-topbar-main-title-size': 0.96,
-    '--kesson-topbar-main-title-size-sm': 0.86,
+    '--as-topbar-link-size': 0.80,
+    '--as-topbar-credit-size': 0.80,
+    '--as-topbar-note-size': 0.80,
+    '--as-topbar-meta-size': 0.80,
+    '--as-topbar-meta-author-size': 0.80,
+    '--as-topbar-subtitle-size-md': 0.80,
+    '--as-topbar-title-size': 0.80,
+    '--as-topbar-main-title-size': 0.96,
+    '--as-topbar-main-title-size-sm': 0.86,
 
     // -- Hero h1 --
-    '--kesson-h1-size': 1.00,
+    '--ds-h1-size': 1.00,
 };
 
 function normalizeStep(step) {

--- a/src/ui/topbar-nav.js
+++ b/src/ui/topbar-nav.js
@@ -1,4 +1,4 @@
-const TOPBAR_ACTUAL_HEIGHT_VAR = '--kesson-topbar-actual-height';
+const TOPBAR_ACTUAL_HEIGHT_VAR = '--as-topbar-actual-height';
 
 function syncTopbarHeight() {
     const topbar = document.getElementById('kesson-topbar');


### PR DESCRIPTION
## 概要

as は ks の token 体系を **完全コピー** (148/150 token) しており、cross-repo prefix 汚染。as 独立性のため `--as-*` リネームで全廃。

詳細: as#141, techo#128 Phase 1a 棚卸し。

## 変更内容

| Layer | token 数 | 置換 |
|-------|---------|------|
| A (pd `--ds-*` 既存) | 38 | `--ds-*` 直接参照 |
| B-existing (as 既存値) | 109 | `--as-*` リネーム |
| B-undef (graphic-switcher-*) | 2 | `--as-*` リネーム + ks 値取り込み |
| UNK-shadow | 1 | `--as-viewer-glass-shadow` (multi-line) |
| UNK-dynamic | 1 | `--as-topbar-actual-height` (JS) |
| UNK-as-only | 1 | `--as-font-sans-ui` |

**影響**: 12 css + 2 js + 1 html = 14 files (+367 / -395)

## 検証済

- [x] `grep -rn "\-\-kesson-" src/ dev-components.html` 残存ゼロ (コメント 2 行除く)
- [x] tokens.css 重複なし、braces matched
- [x] sed は token 名長さ降順 → 部分一致衝突なし

## 動作確認 (要 reviewer)

- [ ] dev サーバ起動 → `index.html` の topbar / viewer / md
- [ ] `dev-components.html`
- [ ] `?dev` で dev-hud / dev-panel
- [ ] font-size-ctrl の動作

## 並行依存

本 PR は **依存なしで merge 可** (Layer B は暫定 `--as-*`、後の Phase 2 で pd 昇格時に剥がす)。

## 関連

- 親: [techo#128](https://github.com/uminomae/techo/issues/128)
- 指示書: [as#141](https://github.com/uminomae/awareness-space/issues/141)
- 先行: [cs#236](https://github.com/uminomae/creation-space/issues/236) / [cs#237](https://github.com/uminomae/creation-space/pull/237) (cs で同パターン完了)

🤖 Generated with [Claude Code](https://claude.com/claude-code)